### PR TITLE
Add block indent support and remove alignment for assignment and property

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -215,6 +215,9 @@ indent_braces_no_struct                 = false         # boolean (false/true)
 # Double indent size for Indentation options
 indent_func_param_double                = false         # boolean (false/true)
 
+# Indent ObjC block
+indent_oc_block                         = true          # boolean (false/true)
+
 # Indent braces
 indent_braces                           = false         # boolean (false/true)
 

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,6 +1,6 @@
 #
 # Uncrustify Configuration File
-# File Created With UncrustifyX 0.4.2 (245)
+# File Created With UncrustifyX 0.4.3 (252)
 #
 
 # Alignment
@@ -47,10 +47,10 @@ align_oc_msg_colon_span                 = 16            # number
 align_oc_msg_spec_span                  = 1             # number
 
 # Alignment span for assignment
-align_assign_span                       = 1             # number
+align_assign_span                       = 0             # number
 
 # Alignment span for variable definitions
-align_var_def_span                      = 1             # number
+align_var_def_span                      = 0             # number
 
 ## Alignment Style
 


### PR DESCRIPTION
1. Default settings will add one more blank space in block code 
2. Alignment for continued assignment or property looks ugly

From
```objective-c
@property (nonatomic) BOOL             testBool;
@property (nonatomic) UIViewController testViewControlelr;
```
to
```objective-c
@property (nonatomic) BOOL testBool;
@property (nonatomic) UIViewController testViewControlelr;
```