### PR TITLE
Force to add a space in method call and change the span of message spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can distribute your configurations over pull request.
 
 ## Installation
 
-1. using [HomeBrew](http://mxcl.github.io/homebrew/) install Uncrustify 
+1. using [HomeBrew](http://mxcl.github.io/homebrew/) install Uncrustify
 ```
 brew install uncrustify --HEAD
 ```
@@ -26,9 +26,14 @@ brew install uncrustify --HEAD
 git clone https://github.com/dijkst/uncrustify-config-ios.git ~/.uncrustify
 ```
 
+### Custom
+
+Default settings disable the alignment of continued assignment or variable definition. If you need them, just set `align_assign_span`, `align_var_def_span` and `align_oc_msg_spec_span` to `1`.
+
+
 ## Example
 
-#### align code:
+#### ~~align code~~ (unsupported, please read `Custom`):
 
 before:
 ``` objective-c
@@ -75,4 +80,4 @@ and so on.
 
 ## License
 
-uncrustify-config-ios is available under the MIT license. 
+uncrustify-config-ios is available under the MIT license.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -44,7 +44,7 @@ align_number_left                       = false         # boolean (false/true)
 align_oc_msg_colon_span                 = 16            # number
 
 # Alignment span for ObjC message spec
-align_oc_msg_spec_span                  = 1             # number
+align_oc_msg_spec_span                  = 0             # number
 
 # Alignment span for assignment
 align_assign_span                       = 0             # number

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -517,6 +517,9 @@ sp_after_oc_colon                       = remove        # string (add/force/igno
 # Space after ObjC message colon
 sp_after_send_oc_colon                  = remove        # string (add/force/ignore/remove)
 
+# Space after ObjC message receiver
+sp_after_oc_msg_receiver                = force         # string (add/force/ignore/remove)
+
 # Space after ObjC return type
 sp_after_oc_return_type                 = remove        # string (add/force/ignore/remove)
 


### PR DESCRIPTION
* From: `id test = [[self class]initWithSomething:something];`
to:` id test = [[self class] initWithSomething:something];`

* set `align_oc_msg_spec_span` to `0`
```objective-c
- (NSURL *)       testUrl;
- (NSDictionary *)testDic;
```
to:
```objective-c
- (NSURL *)testUrl;
- (NSDictionary *)testDic;
```

* Update README