### PR TITLE
Indent case in switch using 4 spaces

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -250,6 +250,9 @@ indent_brace_parent                     = false         # boolean (false/true)
 # Indentation column size
 indent_columns                          = 4             # number
 
+# Indentation size between case and switch
+indent_switch_case                      = 4             # number
+
 ## Other
 
 # Align continued statements at equals


### PR DESCRIPTION
Add option to indent switch/case correctly as suggested by [raywenderlich/objective-c-style-guide#case-statements](https://github.com/raywenderlich/objective-c-style-guide#case-statements).
